### PR TITLE
Add StoryViz project parser

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for StoryViz utilities."""

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,82 @@
+"""Model definitions for StoryViz backend parsing.
+
+The models are intentionally lightweight and rely solely on the Python
+standard library to ease portability inside the StoryViz toolkit.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Chapter:
+    """Represents a single chapter or scene block for StoryViz."""
+
+    title: str
+    summary: Optional[str] = None
+    scenes: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Chapter":
+        if not isinstance(data, dict):
+            raise ValueError("Chapter data must be a dictionary.")
+        title = data.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise ValueError("Chapter title must be a non-empty string.")
+        summary = data.get("summary")
+        if summary is not None and not isinstance(summary, str):
+            raise ValueError("Chapter summary must be a string when provided.")
+        scenes_raw = data.get("scenes", [])
+        if not isinstance(scenes_raw, list) or not all(isinstance(scene, str) for scene in scenes_raw):
+            raise ValueError("Chapter scenes must be a list of strings.")
+        return cls(title=title.strip(), summary=summary, scenes=[scene.strip() for scene in scenes_raw])
+
+
+@dataclass
+class ProjectFull:
+    """Full project payload returned by the LLM for StoryViz."""
+
+    name: str
+    description: Optional[str] = None
+    audience: Optional[str] = None
+    chapters: List[Chapter] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ProjectFull":
+        if not isinstance(data, dict):
+            raise ValueError("Project data must be a dictionary.")
+        name = data.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("Project name must be a non-empty string.")
+        description = data.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValueError("Project description must be a string when provided.")
+        audience = data.get("audience")
+        if audience is not None and not isinstance(audience, str):
+            raise ValueError("Project audience must be a string when provided.")
+        chapters_raw = data.get("chapters", [])
+        if not isinstance(chapters_raw, list):
+            raise ValueError("Project chapters must be a list of dictionaries.")
+        chapters = [Chapter.from_dict(chapter) for chapter in chapters_raw]
+        return cls(
+            name=name.strip(),
+            description=description,
+            audience=audience,
+            chapters=chapters,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "audience": self.audience,
+            "chapters": [
+                {
+                    "title": chapter.title,
+                    "summary": chapter.summary,
+                    "scenes": list(chapter.scenes),
+                }
+                for chapter in self.chapters
+            ],
+        }

--- a/backend/story_parser.py
+++ b/backend/story_parser.py
@@ -1,0 +1,52 @@
+"""StoryViz helpers for parsing LLM output into backend models."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from backend.models import ProjectFull
+
+
+class InvalidProjectDataError(Exception):
+    """Se lanza cuando el JSON devuelto por el LLM no cumple el esquema de ProjectFull."""
+
+
+def _load_response_json(response_text: str) -> Any:
+    """Carga la respuesta del LLM como JSON.
+
+    Args:
+        response_text: Cadena devuelta por el LLM.
+
+    Raises:
+        InvalidProjectDataError: Si el texto no es JSON válido.
+
+    Returns:
+        Objeto Python resultante de `json.loads`.
+    """
+
+    try:
+        return json.loads(response_text)
+    except json.JSONDecodeError as exc:
+        msg = "La respuesta del LLM no es un JSON válido."
+        raise InvalidProjectDataError(msg) from exc
+
+
+def parse_project(response_text: str) -> ProjectFull:
+    """Parsea la respuesta del LLM y la transforma en un ``ProjectFull``.
+
+    Args:
+        response_text: Texto completo devuelto por el LLM.
+
+    Raises:
+        InvalidProjectDataError: Si el JSON no respeta el esquema esperado.
+
+    Returns:
+        Instancia validada de :class:`ProjectFull`.
+    """
+
+    data = _load_response_json(response_text)
+    try:
+        return ProjectFull.from_dict(data)
+    except Exception as exc:  # pragma: no cover - defensive, should be rare.
+        msg = "El JSON no cumple con el esquema de ProjectFull."
+        raise InvalidProjectDataError(msg) from exc


### PR DESCRIPTION
## Summary
- add lightweight backend models for StoryViz project and chapter data
- add parser that converts LLM JSON responses into validated ProjectFull instances
- initialize backend package for StoryViz utilities

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69239d1eb034833380f8b6443ba4c2cd)