### PR TITLE
Add StoryViz models and parsing utilities

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,45 @@
+"""Pydantic models for StoryViz projects."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class ProjectManifest(BaseModel):
+    """Metadata about the project."""
+
+    title: str = Field(..., description="Título del proyecto")
+    description: str = Field(..., description="Descripción breve del proyecto")
+    duration_seconds: int = Field(..., ge=0, description="Duración total objetivo en segundos")
+    target_platforms: List[str] = Field(..., description="Plataformas de destino del video")
+
+
+class SceneV3(BaseModel):
+    """Represents an individual scene."""
+
+    id: str = Field(..., description="Identificador único de la escena")
+    title: str = Field(..., description="Título corto de la escena")
+    description: str = Field(..., description="Descripción de lo que ocurre")
+    duration_seconds: int = Field(..., ge=0, description="Duración aproximada de la escena")
+    visual_style: Optional[str] = Field(None, description="Referencias visuales o estilo")
+    audio_cues: Optional[str] = Field(None, description="Instrucciones de audio/locución")
+
+    @validator("id")
+    def id_not_empty(cls, value: str) -> str:  # noqa: D417
+        if not value.strip():
+            raise ValueError("id must not be empty")
+        return value
+
+
+class ProjectFull(BaseModel):
+    """Full project definition including manifest and scenes."""
+
+    manifest: ProjectManifest
+    scenes: List[SceneV3]
+
+    @validator("scenes")
+    def at_least_one_scene(cls, value: List[SceneV3]) -> List[SceneV3]:  # noqa: D417
+        if not value:
+            raise ValueError("At least one scene is required")
+        return value

--- a/backend/story_parser.py
+++ b/backend/story_parser.py
@@ -1,0 +1,110 @@
+"""Utilities to build prompts and parse StoryViz project data."""
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+from typing import List
+
+from backend.models import ProjectFull
+
+
+class InvalidProjectDataError(Exception):
+    """Se lanza cuando el JSON devuelto por el LLM no cumple el esquema de ProjectFull."""
+
+
+PROMPT_HEADER = "Convierte este script en un JSON que siga EXACTAMENTE el esquema ProjectFull"
+
+
+def build_prompt_for_story_to_project(
+    script: str, duracion_objetivo: int, plataformas_destino: List[str]
+) -> str:
+    """Construye un prompt en español para convertir un guion en ProjectFull."""
+
+    scene_limit_rule = (
+        "- Si la duración objetivo es de 90 segundos o menos, limita el JSON a un máximo de 8 escenas."
+    )
+    prompt = dedent(
+        f"""
+        Rol: {PROMPT_HEADER}.
+        Reglas estrictas:
+        - Devuelve únicamente JSON VÁLIDO. No incluyas texto fuera del JSON ni explicaciones.
+        - {scene_limit_rule if duracion_objetivo <= 90 else "- Usa el número de escenas que necesites, pero optimiza la duración."}
+        - Las duraciones de las escenas deben aproximar la duración objetivo total (segundos): {duracion_objetivo}.
+        - Rellena todos los campos obligatorios de ProjectManifest y SceneV3.
+        - Usa valores razonables por defecto cuando falte información en el script.
+        - Plataformas destino sugeridas: {plataformas_destino}.
+
+        Esquema esperado (resumen):
+        {{
+          "manifest": {{
+            "title": str,
+            "description": str,
+            "duration_seconds": int,
+            "target_platforms": list[str]
+          }},
+          "scenes": [
+            {{
+              "id": str,
+              "title": str,
+              "description": str,
+              "duration_seconds": int,
+              "visual_style": str | null,
+              "audio_cues": str | null
+            }},
+            ...
+          ]
+        }}
+
+        Ejemplo de JSON (sólo ilustrativo, adapta a tu respuesta):
+        {{
+          "manifest": {{
+            "title": "Búsqueda submarina",
+            "description": "Una exploradora desciende por un templo sumergido para recuperar un artefacto legendario.",
+            "duration_seconds": 90,
+            "target_platforms": ["tiktok", "youtube_short"]
+          }},
+          "scenes": [
+            {{
+              "id": "s1",
+              "title": "Inmersión",
+              "description": "La exploradora se sumerge entre ruinas iluminadas por su linterna.",
+              "duration_seconds": 30,
+              "visual_style": "Tonos azules, luz tenue",
+              "audio_cues": "Efectos de burbujas, música de tensión"
+            }},
+            {{
+              "id": "s2",
+              "title": "La cámara sellada",
+              "description": "Encuentra el artefacto protegido por un campo de energía.",
+              "duration_seconds": 30,
+              "visual_style": "Brillos verdes, runas antiguas",
+              "audio_cues": "Zumbido energético, respiración contenida"
+            }}
+          ]
+        }}
+
+        Script original:
+        {script}
+        """
+    ).strip()
+    return prompt
+
+
+def parse_llm_response_to_project(json_str: str) -> ProjectFull:
+    """Parsea la respuesta JSON del LLM y devuelve un ProjectFull validado."""
+
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
+        raise InvalidProjectDataError(f"JSON inválido: {exc}") from exc
+
+    try:
+        return ProjectFull(**data)
+    except Exception as exc:  # pragma: no cover - pydantic validation errors
+        raise InvalidProjectDataError(f"Datos incompatibles con ProjectFull: {exc}") from exc
+
+
+if __name__ == "__main__":
+    script = "Una exploradora desciende a una ciudad sumergida para recuperar un artefacto."
+    prompt = build_prompt_for_story_to_project(script, 90, ["tiktok", "youtube_short"])
+    print(prompt)


### PR DESCRIPTION
## Summary
- add Pydantic models for StoryViz project manifests, scenes, and full project payloads
- implement story parser utilities to build LLM prompts and validate JSON responses

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69239ef8f6608333b7cc2a16debe8fff)