### PR TITLE
Add local LLM client and demo script

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,18 @@
+from .llm_client import LocalLLMClient, generate_project_from_script
+from .models import ProjectFull, Scene
+from .story_parser import (
+    InvalidProjectDataError,
+    build_prompt_for_story_to_project,
+    parse_llm_response_to_project,
+)
+
+__all__ = [
+    "LocalLLMClient",
+    "generate_project_from_script",
+    "ProjectFull",
+    "Scene",
+    "InvalidProjectDataError",
+    "build_prompt_for_story_to_project",
+    "parse_llm_response_to_project",
+]
+

--- a/backend/demo_local_llm.py
+++ b/backend/demo_local_llm.py
@@ -1,0 +1,31 @@
+from backend.llm_client import LocalLLMClient, generate_project_from_script
+
+
+def main() -> None:
+    script = (
+        "Una joven descubre una nota escondida en un libro de la biblioteca. "
+        "La pista la lleva a investigar un misterio que conecta a su familia con la ciudad. "
+        "Con la ayuda de un amigo, decide seguir las señales pese a sus dudas."
+    )
+
+    llm = LocalLLMClient(model="llama3")
+    project = generate_project_from_script(
+        script=script,
+        llm=llm,
+        duracion_objetivo=90,
+        plataformas_destino=["tiktok", "youtube_short"],
+    )
+
+    print(f"Título: {project.titulo}")
+    print(f"Logline: {project.logline}")
+    print(f"Número de escenas: {len(project.escenas)}")
+    for escena in project.escenas:
+        print(
+            f"Escena {escena.orden}: {escena.duracion_estimada_segundos}s, "
+            f"plano {escena.tipo_plano_dominante}, peso {escena.peso_narrativo}"
+        )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import requests
+from typing import List
+
+from .story_parser import (
+    InvalidProjectDataError,
+    build_prompt_for_story_to_project,
+    parse_llm_response_to_project,
+)
+
+
+class LocalLLMClient:
+    def __init__(self, model: str, base_url: str = "http://localhost:11434", timeout: int = 60) -> None:
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def generate(self, prompt: str, *, max_tokens: int = 2048, temperature: float = 0.7) -> str:
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": temperature, "num_predict": max_tokens},
+        }
+        try:
+            response = requests.post(
+                f"{self.base_url}/api/generate", json=payload, timeout=self.timeout
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("response", "").strip()
+        except requests.RequestException as exc:
+            raise requests.RequestException(f"Error al llamar al LLM local: {exc}") from exc
+
+
+def generate_project_from_script(
+    script: str,
+    llm: LocalLLMClient,
+    *,
+    duracion_objetivo: int,
+    plataformas_destino: List[str],
+) -> object:
+    prompt = build_prompt_for_story_to_project(
+        script=script,
+        duracion_objetivo=duracion_objetivo,
+        plataformas_destino=plataformas_destino,
+    )
+
+    try:
+        llm_output = llm.generate(prompt)
+        return parse_llm_response_to_project(llm_output)
+    except requests.RequestException as exc:
+        raise requests.RequestException(f"Fallo de red al comunicarse con el LLM: {exc}") from exc
+    except InvalidProjectDataError as exc:
+        raise InvalidProjectDataError(
+            f"La respuesta del LLM no se pudo convertir en ProjectFull: {exc}"
+        ) from exc
+
+
+__all__ = ["LocalLLMClient", "generate_project_from_script"]
+

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Scene:
+    orden: int
+    duracion_estimada_segundos: int
+    tipo_plano_dominante: str
+    peso_narrativo: float
+
+
+@dataclass
+class ProjectFull:
+    titulo: str
+    logline: str
+    escenas: List[Scene] = field(default_factory=list)
+

--- a/backend/story_parser.py
+++ b/backend/story_parser.py
@@ -1,0 +1,82 @@
+import json
+import re
+from typing import List
+
+from .models import ProjectFull, Scene
+
+
+class InvalidProjectDataError(Exception):
+    """Raised when the LLM output cannot be converted into a ProjectFull object."""
+
+
+def build_prompt_for_story_to_project(script: str, duracion_objetivo: int, plataformas_destino: List[str]) -> str:
+    plataformas = ", ".join(plataformas_destino)
+    return (
+        "Eres un guionista asistente. Convierte la siguiente historia en un JSON que represente un proyecto audiovisual. "
+        "Sigue este esquema: {\"titulo\": str, \"logline\": str, \"escenas\": ["
+        "{\"orden\": int, \"duracion_estimada_segundos\": int, \"tipo_plano_dominante\": str, \"peso_narrativo\": float}]}. "
+        "No incluyas comentarios ni texto adicional, solo el JSON. "
+        f"Duración objetivo: {duracion_objetivo} segundos. Plataformas destino: {plataformas}. Historia: {script}"
+    )
+
+
+def _extract_json_block(text: str) -> str:
+    match = re.search(r"```json\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
+    if match:
+        return match.group(1)
+    return text.strip()
+
+
+def parse_llm_response_to_project(response_text: str) -> ProjectFull:
+    try:
+        cleaned = _extract_json_block(response_text)
+        data = json.loads(cleaned)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise InvalidProjectDataError(f"No se pudo interpretar la respuesta del LLM como JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise InvalidProjectDataError("El formato del proyecto debe ser un objeto JSON.")
+
+    titulo = data.get("titulo")
+    logline = data.get("logline")
+    escenas_raw = data.get("escenas", [])
+
+    if not isinstance(titulo, str) or not isinstance(logline, str):
+        raise InvalidProjectDataError("El proyecto debe incluir los campos 'titulo' y 'logline' como cadenas.")
+
+    if not isinstance(escenas_raw, list):
+        raise InvalidProjectDataError("El campo 'escenas' debe ser una lista.")
+
+    escenas: List[Scene] = []
+    for escena in escenas_raw:
+        if not isinstance(escena, dict):
+            raise InvalidProjectDataError("Cada escena debe ser un objeto con sus propiedades.")
+
+        try:
+            orden = int(escena["orden"])
+            duracion_estimada_segundos = int(escena["duracion_estimada_segundos"])
+            tipo_plano_dominante = str(escena["tipo_plano_dominante"])
+            peso_narrativo = float(escena["peso_narrativo"])
+        except (KeyError, ValueError, TypeError) as exc:
+            raise InvalidProjectDataError(
+                "Cada escena debe incluir 'orden', 'duracion_estimada_segundos', 'tipo_plano_dominante' y 'peso_narrativo'."
+            ) from exc
+
+        escenas.append(
+            Scene(
+                orden=orden,
+                duracion_estimada_segundos=duracion_estimada_segundos,
+                tipo_plano_dominante=tipo_plano_dominante,
+                peso_narrativo=peso_narrativo,
+            )
+        )
+
+    return ProjectFull(titulo=titulo, logline=logline, escenas=escenas)
+
+
+__all__ = [
+    "InvalidProjectDataError",
+    "build_prompt_for_story_to_project",
+    "parse_llm_response_to_project",
+]
+


### PR DESCRIPTION
## Summary
- add backend datamodels and parsing helpers for project generation
- implement local LLM client with project-generation orchestration and error handling
- add demo script to exercise local LLM project flow

## Testing
- python -m py_compile backend/*.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923a49cc8388333a3c6556813075d70)