### PR TITLE
Add UART boot message

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ The kernel can be run with QEMU using:
 qemu-system-aarch64 -M virt -cpu cortex-a53 -nographic -kernel kernel8.img
 ```
 
-The program performs no visible output, but you can use this as a starting point for further development.
+The kernel writes a short boot message to the PL011 UART, which appears on the `qemu-system-aarch64` console. After printing, it idles in a low-power wait loop.

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,6 +1,26 @@
 #include <stdint.h>
 
+#define UART0_BASE 0x09000000UL
+#define UART_DR (*(volatile uint32_t *)(UART0_BASE + 0x00))
+#define UART_FR (*(volatile uint32_t *)(UART0_BASE + 0x18))
+#define UART_FR_TXFF (1u << 5)
+
+static void uart_putc(char c) {
+    while (UART_FR & UART_FR_TXFF) {
+        // Wait for space in the FIFO
+    }
+    UART_DR = (uint32_t)c;
+}
+
+static void uart_puts(const char *s) {
+    while (*s) {
+        uart_putc(*s++);
+    }
+}
+
 void kernel_main(void) {
+    uart_puts("Booting minimal ARM64 kernel on QEMU virt...\n");
+
     // Loop forever
     while (1) {
         __asm__ volatile("wfe");


### PR DESCRIPTION
## Summary
- add a minimal PL011 UART helper and print a boot message during startup
- leave the kernel in a low-power wait loop after output
- document the UART output expectation in the README

## Testing
- make *(fails: `aarch64-linux-gnu-gcc` not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923a72bd1008333ab3e41b94057ea80)