### PR TITLE
Add StoryViz image prompt builder

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for StoryViz prompt tooling."""

--- a/backend/image_prompt_builder.py
+++ b/backend/image_prompt_builder.py
@@ -1,0 +1,93 @@
+from typing import List
+
+from backend.models import ProjectManifest, SceneV3, ShotV3
+
+
+def build_base_image_prompt(
+    manifest: ProjectManifest,
+    scene: SceneV3,
+    tipo_plano: str,
+) -> str:
+    """
+    Construye un prompt base para SDXL/Juggernaut usando bloques cinematográficos:
+    - Sujeto/acción
+    - Entorno/escenario
+    - Iluminación
+    - Color / mood
+    - Cámara y objetivo
+    - Composición
+    - Estilo visual / modelo
+    """
+    sujeto_accion = scene.description or scene.title
+    entorno = scene.location or "entorno sin especificar"
+    iluminacion = manifest.lighting or scene.time_of_day or "iluminación cinematográfica suave"
+    mood = scene.mood or manifest.genre or "dramático"
+    camara = manifest.camera_style or "lente anamórfico, profundidad de campo"
+    composicion = f"{tipo_plano}, composición dinámica, regla de los tercios"
+
+    estilo = scene.visual_style or manifest.visual_style or "realismo detallado"
+    modelo = manifest.target_model or "SDXL, Juggernaut"
+    color = manifest.color_palette or "color grading cinematográfico"
+    keywords = ", ".join(manifest.keywords) if manifest.keywords else ""
+
+    bloques = [
+        f"Sujeto y acción: {sujeto_accion}.",
+        f"Entorno: {entorno}.",
+        f"Iluminación: {iluminacion}.",
+        f"Color y mood: {color}, tono {mood}.",
+        f"Cámara: {camara}.",
+        f"Composición: {composicion}.",
+        f"Estilo visual: {estilo}, modelo {modelo}.",
+    ]
+
+    if keywords:
+        bloques.append(f"Palabras clave: {keywords}.")
+
+    return " ".join(bloques)
+
+
+def build_shots_from_scene(manifest: ProjectManifest, scene: SceneV3) -> List[ShotV3]:
+    """
+    Genera una lista de ShotV3 con prompts listos para SDXL/Juggernaut.
+
+    La escena puede aportar descripciones de planos en ``scene.shots``; si no
+    existen, se usan los ``beats`` o un plano genérico basado en la descripción.
+    Cada prompt aplica el bloque base y añade una acción específica para el plano.
+    """
+    fuentes = scene.shots or [
+        {"tipo_plano": "plano medio", "detalle": beat} for beat in scene.beats
+    ]
+
+    if not fuentes:
+        fuentes = [{"tipo_plano": "plano medio", "detalle": scene.description}]
+
+    shots: List[ShotV3] = []
+    for indice, fuente in enumerate(fuentes, start=1):
+        tipo_plano = fuente.get("tipo_plano") or "plano medio"
+        detalle = (
+            fuente.get("detalle")
+            or fuente.get("descripcion")
+            or scene.description
+            or scene.title
+        )
+
+        base_prompt = build_base_image_prompt(manifest, scene, tipo_plano)
+        prompt = " ".join(
+            [
+                base_prompt,
+                f"Acción del plano: {detalle}.",
+                "Cinema quality, 8k, ultra detailed, high dynamic range, aspect ratio 16:9.",
+            ]
+        )
+
+        shots.append(
+            ShotV3(
+                order=indice,
+                tipo_plano=tipo_plano,
+                prompt=prompt,
+                negative_prompt=manifest.negative_prompt,
+                notes=fuente.get("notas"),
+            )
+        )
+
+    return shots

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class ProjectManifest:
+    """
+    Datos de alto nivel para un proyecto StoryViz.
+
+    Los campos son opcionales para permitir que el generador de prompts funcione
+    incluso cuando falten detalles en el manifiesto.
+    """
+
+    title: str
+    genre: Optional[str] = None
+    visual_style: Optional[str] = None
+    color_palette: Optional[str] = None
+    lighting: Optional[str] = None
+    camera_style: Optional[str] = None
+    target_model: Optional[str] = None
+    negative_prompt: Optional[str] = None
+    keywords: List[str] = field(default_factory=list)
+
+
+@dataclass
+class SceneV3:
+    """
+    Representa una escena dentro del proyecto.
+
+    `shots` puede contener descripciones predefinidas para cada plano, por
+    ejemplo: {"tipo_plano": "primer plano", "detalle": "el protagonista mira"}.
+    """
+
+    id: str
+    title: str
+    description: str
+    location: Optional[str] = None
+    time_of_day: Optional[str] = None
+    mood: Optional[str] = None
+    visual_style: Optional[str] = None
+    beats: List[str] = field(default_factory=list)
+    shots: List[dict] = field(default_factory=list)
+
+
+@dataclass
+class ShotV3:
+    """Plano individual con un prompt cinematográfico listo para imagen."""
+
+    order: int
+    tipo_plano: str
+    prompt: str
+    negative_prompt: Optional[str] = None
+    notes: Optional[str] = None
+
+
+__all__ = ["ProjectManifest", "SceneV3", "ShotV3"]


### PR DESCRIPTION
## Summary
- add StoryViz data models for projects, scenes, and shots
- build cinematic SDXL/Juggernaut prompt generator using manifest and scene metadata
- initialize backend package for prompt tooling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923acc6983483338ef172221ab38d0b)