### PR TITLE
Add UART greeting output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Minimal ARM64 Kernel Example
 
-This repository contains a very small example of a bare-metal AArch64 (ARM64) kernel. The code boots on the QEMU `virt` machine and immediately enters an infinite low-power wait loop.
+This repository contains a very small example of a bare-metal AArch64 (ARM64) kernel. The code boots on the QEMU `virt` machine
+and writes a short greeting to the PL011 UART before entering an infinite low-power wait loop.
 
 ## Building
 
@@ -26,4 +27,10 @@ The kernel can be run with QEMU using:
 qemu-system-aarch64 -M virt -cpu cortex-a53 -nographic -kernel kernel8.img
 ```
 
-The program performs no visible output, but you can use this as a starting point for further development.
+On startup, the kernel prints a greeting such as:
+
+```
+Hello from the minimal AArch64 kernel!
+```
+
+The program then waits indefinitely, which you can use as a starting point for further development.

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,6 +1,30 @@
 #include <stdint.h>
 
+#define UART0_BASE 0x09000000UL
+#define UART0_DR   ((volatile uint32_t *)(UART0_BASE + 0x00))
+#define UART0_FR   ((volatile uint32_t *)(UART0_BASE + 0x18))
+#define UART_FR_TXFF (1u << 5)
+
+static void uart_putc(char c) {
+    // Wait until the transmit FIFO is not full
+    while (*UART0_FR & UART_FR_TXFF) {
+        __asm__ volatile("wfe");
+    }
+    *UART0_DR = (uint32_t)c;
+}
+
+static void uart_puts(const char *s) {
+    while (*s) {
+        if (*s == '\n') {
+            uart_putc('\r');
+        }
+        uart_putc(*s++);
+    }
+}
+
 void kernel_main(void) {
+    uart_puts("Hello from the minimal AArch64 kernel!\n");
+
     // Loop forever
     while (1) {
         __asm__ volatile("wfe");


### PR DESCRIPTION
## Summary
- send a greeting string over the PL011 UART when the kernel starts
- document the UART greeting behavior in the README

## Testing
- make *(fails: `aarch64-linux-gnu-gcc` not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692443e76dd4833396ad4a7f36d4fb01)