### PR TITLE
Add configurable toolchain and QEMU run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,30 @@
-CROSS_COMPILE=aarch64-linux-gnu-
-CC=$(CROSS_COMPILE)gcc
-LD=$(CROSS_COMPILE)ld
-OBJCOPY=$(CROSS_COMPILE)objcopy
-CFLAGS=-nostdlib -nostartfiles -ffreestanding -fno-builtin -Wall -O2
+CROSS_COMPILE ?= aarch64-linux-gnu-
+CC := $(CROSS_COMPILE)gcc
+LD := $(CROSS_COMPILE)ld
+OBJCOPY := $(CROSS_COMPILE)objcopy
+CFLAGS := -nostdlib -nostartfiles -ffreestanding -fno-builtin -Wall -O2
+
+QEMU ?= qemu-system-aarch64
+QEMU_FLAGS := -M virt -cpu cortex-a53 -nographic
 
 all: kernel8.img
 
 boot.o: src/boot.S
-	$(CC) $(CFLAGS) -c -o boot.o src/boot.S
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 kernel.o: src/kernel.c
-	$(CC) $(CFLAGS) -c -o kernel.o src/kernel.c
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 kernel8.elf: boot.o kernel.o linker.ld
-	$(LD) -T linker.ld -o kernel8.elf boot.o kernel.o
+	$(LD) -T linker.ld -o $@ boot.o kernel.o
 
 kernel8.img: kernel8.elf
-	$(OBJCOPY) -O binary kernel8.elf kernel8.img
+	$(OBJCOPY) -O binary $< $@
+
+run: kernel8.img
+	$(QEMU) $(QEMU_FLAGS) -kernel $<
 
 clean:
 	rm -f *.o kernel8.elf kernel8.img
 
-.PHONY: all clean
+.PHONY: all clean run

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Minimal ARM64 Kernel Example
 
-This repository contains a very small example of a bare-metal AArch64 (ARM64) kernel. The code boots on the QEMU `virt` machine and immediately enters an infinite low-power wait loop.
+This repository contains a very small example of a bare-metal AArch64 (ARM64) kernel. The code boots on the QEMU `virt` machine
+and immediately enters an infinite low-power wait loop.
 
 ## Building
 
@@ -8,6 +9,12 @@ A cross compiler for AArch64 is required. On Ubuntu it can be installed with:
 
 ```sh
 sudo apt-get install gcc-aarch64-linux-gnu
+```
+
+You can override the toolchain prefix if you have a different cross compiler available by setting `CROSS_COMPILE`:
+
+```sh
+CROSS_COMPILE=aarch64-elf- make
 ```
 
 Build the kernel image:
@@ -24,6 +31,12 @@ The kernel can be run with QEMU using:
 
 ```sh
 qemu-system-aarch64 -M virt -cpu cortex-a53 -nographic -kernel kernel8.img
+```
+
+Alternatively, the `run` target wraps this command:
+
+```sh
+make run
 ```
 
 The program performs no visible output, but you can use this as a starting point for further development.


### PR DESCRIPTION
## Summary
- allow overriding the cross-compiler prefix instead of hard-coding it
- add a `run` target and QEMU configuration variables to the Makefile
- document the configurable toolchain and the new `make run` helper in the README

## Testing
- make -n


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692444a487888333a823f787ecf1bb97)