### PR TITLE
Zero-initialize BSS before kernel start

### DIFF
--- a/src/boot.S
+++ b/src/boot.S
@@ -4,6 +4,18 @@
 _start:
     ldr x0, =_stack_top
     mov sp, x0
+
+    /* Zero-initialize the .bss section */
+    ldr x1, =_bss_start
+    ldr x2, =_bss_end
+    mov x3, #0
+1:
+    cmp x1, x2
+    b.ge 2f
+    str x3, [x1], #8
+    b 1b
+2:
+
     bl kernel_main
 1:
     wfe


### PR DESCRIPTION
## Summary
- initialize the .bss section to zero during startup before calling `kernel_main`

## Testing
- make *(fails: missing `aarch64-linux-gnu-gcc` toolchain)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924459be71c83338090b9b21036473c)