### PR TITLE
Add FastAPI app for uvicorn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ qemu-system-aarch64 -M virt -cpu cortex-a53 -nographic -kernel kernel8.img
 ```
 
 The program performs no visible output, but you can use this as a starting point for further development.
+
+## Running the FastAPI app
+
+A small FastAPI application is included for convenience. Install dependencies and run it with Uvicorn:
+
+```sh
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Visit http://localhost:8000/ to see a greeting or http://localhost:8000/health for a basic health check.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="IMO API")
+
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    """Return a simple greeting to confirm the app is running."""
+    return {"message": "Hello from FastAPI"}
+
+
+@app.get("/health")
+def read_health() -> dict[str, str]:
+    """Health endpoint useful for readiness and liveness probes."""
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.0


### PR DESCRIPTION
## Summary
- add a minimal FastAPI application with root and health endpoints
- provide dependency pins for running the API via Uvicorn
- document how to install dependencies and launch the server

## Testing
- python -m pip install -r requirements.txt

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692445b362688333ab037acf52647929)