### PR TITLE
Add UART hello output for kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ The kernel can be run with QEMU using:
 qemu-system-aarch64 -M virt -cpu cortex-a53 -nographic -kernel kernel8.img
 ```
 
-The program performs no visible output, but you can use this as a starting point for further development.
+On boot, the kernel now writes `Hello from the StoryViz kernel!` to the PL011 UART (displayed in the QEMU console) and then enters a low-power wait loop.

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,6 +1,31 @@
 #include <stdint.h>
 
+// PL011 UART base address on QEMU's virt machine
+#define UART0_BASE 0x09000000UL
+#define UART0_DR   (*(volatile uint32_t *)(UART0_BASE + 0x00))
+#define UART0_FR   (*(volatile uint32_t *)(UART0_BASE + 0x18))
+#define UART_FR_TXFF 0x20
+
+static void uart_putc(char c) {
+    // Wait until the transmit FIFO is not full
+    while (UART0_FR & UART_FR_TXFF) {
+        __asm__ volatile("wfe");
+    }
+    UART0_DR = (uint32_t)c;
+}
+
+static void uart_puts(const char *s) {
+    while (*s) {
+        if (*s == '\n') {
+            uart_putc('\r');
+        }
+        uart_putc(*s++);
+    }
+}
+
 void kernel_main(void) {
+    uart_puts("Hello from the StoryViz kernel!\n");
+
     // Loop forever
     while (1) {
         __asm__ volatile("wfe");


### PR DESCRIPTION
## Summary
- send a greeting message over the PL011 UART during kernel startup
- document the visible UART output in the README for QEMU runs

## Testing
- make *(fails: aarch64-linux-gnu-gcc not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692446c66ef8833393213e8bdbd3c472)