### PR TITLE
Add FastAPI app for development server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ qemu-system-aarch64 -M virt -cpu cortex-a53 -nographic -kernel kernel8.img
 ```
 
 The program performs no visible output, but you can use this as a starting point for further development.
+
+## Running the development API server
+
+This repository also contains a minimal FastAPI application for experimentation. Install the Python dependencies and start the server with:
+
+```sh
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+The API responds on http://127.0.0.1:8000/ with a simple JSON status payload.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Minimal Kernel API")
+
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    """Return a simple status message."""
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.1


### PR DESCRIPTION
## Summary
- add a minimal FastAPI application with a root status endpoint
- document how to install dependencies and run the development API server
- capture Python dependencies for running uvicorn

## Testing
- python -m compileall main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924473dd3a08333afae2db5893b52a1)